### PR TITLE
Add BLE mesh gateway support for hub-proxied lights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Local test virtualenv
+.venv/
+
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/custom_components/aidot/ble_gateway_client.py
+++ b/custom_components/aidot/ble_gateway_client.py
@@ -1,0 +1,221 @@
+"""BLE mesh device client that proxies commands through an AiDot hub."""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import json
+import struct
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from aidot.aes_utils import aes_encrypt as _aes_encrypt_raw, aes_decrypt as _aes_decrypt_raw
+
+_HUB_PORT = 10000
+_TIMEOUT = 8
+
+
+def _make_aes_key(key_str: str) -> bytes:
+    k = bytearray(16)
+    b = key_str.encode()
+    k[: len(b)] = b
+    return bytes(k)
+
+
+def _aes_encrypt(data: bytes, key: bytes) -> bytes:
+    return _aes_encrypt_raw(data, key)
+
+
+def _aes_decrypt(data: bytes, key: bytes) -> str:
+    return _aes_decrypt_raw(data, key)  # library returns str
+
+
+def _frame(msg: bytes, key: bytes) -> bytes:
+    enc = _aes_encrypt(msg, key)
+    return struct.pack(">Hhi", 0x1EED, 1, len(enc)) + enc
+
+
+async def _recv(reader: asyncio.StreamReader, key: bytes) -> dict:
+    hdr = await asyncio.wait_for(reader.readexactly(8), timeout=_TIMEOUT)
+    _, _, size = struct.unpack(">HHI", hdr)
+    body = await asyncio.wait_for(reader.readexactly(size), timeout=_TIMEOUT)
+    raw = _aes_decrypt_raw(body, key)
+    return json.loads(raw)
+
+
+@dataclass
+class BleDeviceInfo:
+    dev_id: str
+    model_id: str
+    mac: str
+    name: str
+    hw_version: str | None
+    enable_rgbw: bool
+    enable_cct: bool
+    cct_min: int = 2700
+    cct_max: int = 6500
+
+
+@dataclass
+class BleDeviceStatus:
+    online: bool = True
+    on: bool = False
+    dimming: int = 255
+    cct: int = 2700
+    rgbw: tuple[int, int, int, int] = field(default_factory=lambda: (255, 255, 255, 0))
+
+
+_seq = 0
+
+
+def _next_seq() -> str:
+    global _seq
+    _seq += 1
+    return "ha93" + str(_seq).zfill(5)
+
+
+class BleGatewayDeviceClient:
+    """Controls a BLE mesh light by proxying commands through the AiDot hub's TCP port."""
+
+    def __init__(self, device: dict, hub_device: dict, user_id: str) -> None:
+        self._device_id: str = device["id"]
+        self._hub_id: str = hub_device["id"]
+        self._hub_ip: str = hub_device.get("properties", {}).get("ipAddress", "")
+        self._hub_password: str = hub_device.get("password", "")
+        self._user_id: str = user_id
+        self._aes_key: bytes = _make_aes_key(
+            (hub_device.get("aesKey") or [None])[0] or ""
+        )
+
+        modules = {
+            m["identity"]
+            for m in device.get("product", {}).get("serviceModules", [])
+        }
+        enable_rgbw = "control.light.rgbw" in modules
+        enable_cct = "control.light.cct" in modules
+
+        cct_min, cct_max = 2700, 6500
+        for m in device.get("product", {}).get("serviceModules", []):
+            if m["identity"] == "control.light.cct":
+                for p in m.get("properties", []):
+                    if p.get("identity") == "CCT":
+                        try:
+                            cct_min = int(p.get("minValue", cct_min))
+                            cct_max = int(p.get("maxValue", cct_max))
+                        except (ValueError, TypeError):
+                            pass
+
+        self.info = BleDeviceInfo(
+            dev_id=self._device_id,
+            model_id=device.get("modelId", "unknown"),
+            mac=device.get("mac", ""),
+            name=device.get("name", ""),
+            hw_version=device.get("hardwareVersion"),
+            enable_rgbw=enable_rgbw,
+            enable_cct=enable_cct,
+            cct_min=cct_min,
+            cct_max=cct_max,
+        )
+
+        props = device.get("properties", {})
+        raw_dim = int(props.get("Dimming", 100))
+        raw_rgbw = int(props.get("RGBW", 0))
+        rgbw_u = ctypes.c_uint32(raw_rgbw).value
+
+        self.status = BleDeviceStatus(
+            online=True,
+            on=int(props.get("OnOff", 0)) == 1,
+            dimming=int(raw_dim * 255 / 100),
+            cct=int(props.get("CCT", cct_min)),
+            rgbw=(
+                (rgbw_u >> 24) & 0xFF,
+                (rgbw_u >> 16) & 0xFF,
+                (rgbw_u >> 8) & 0xFF,
+                rgbw_u & 0xFF,
+            ),
+        )
+        self.on_status_update: Any = None
+
+    async def _send(self, attr: dict) -> None:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(self._hub_ip, _HUB_PORT), timeout=_TIMEOUT
+        )
+        try:
+            seq = str(int(time.time() * 1000) + 1)[-9:]
+            login = json.dumps({
+                "service": "device",
+                "method": "loginReq",
+                "seq": seq,
+                "srcAddr": self._user_id,
+                "deviceId": self._hub_id,
+                "payload": {
+                    "userId": self._user_id,
+                    "password": self._hub_password,
+                    "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
+                    "ascNumber": 1,
+                },
+            }).encode()
+            writer.write(_frame(login, self._aes_key))
+            await writer.drain()
+
+            resp = await _recv(reader, self._aes_key)
+            asc = resp.get("payload", {}).get("ascNumber", 1) + 1
+
+            cmd = json.dumps({
+                "method": "setDevAttrReq",
+                "service": "device",
+                "clientId": "ha-" + self._user_id,
+                "srcAddr": "0." + self._user_id,
+                "seq": _next_seq(),
+                "payload": {
+                    "devId": self._device_id,
+                    "parentId": self._hub_id,
+                    "userId": self._user_id,
+                    "password": self._hub_password,
+                    "attr": attr,
+                    "channel": "ble",
+                    "ascNumber": asc,
+                },
+                "tst": int(time.time() * 1000),
+                "deviceId": self._device_id,
+            }).encode()
+            writer.write(_frame(cmd, self._aes_key))
+            await writer.drain()
+            await _recv(reader, self._aes_key)
+        finally:
+            writer.close()
+
+        if "OnOff" in attr:
+            self.status.on = bool(attr["OnOff"])
+        if "Dimming" in attr:
+            self.status.dimming = int(attr["Dimming"] * 255 / 100)
+        if "CCT" in attr:
+            self.status.cct = attr["CCT"]
+        if "RGBW" in attr:
+            packed = ctypes.c_uint32(attr["RGBW"]).value
+            self.status.rgbw = (
+                (packed >> 24) & 0xFF,
+                (packed >> 16) & 0xFF,
+                (packed >> 8) & 0xFF,
+                packed & 0xFF,
+            )
+        if self.on_status_update:
+            self.on_status_update(self.status)
+
+    async def async_turn_on(self) -> None:
+        await self._send({"OnOff": 1})
+
+    async def async_turn_off(self) -> None:
+        await self._send({"OnOff": 0})
+
+    async def async_set_brightness(self, brightness: int) -> None:
+        await self._send({"OnOff": 1, "Dimming": int(brightness * 100 / 255)})
+
+    async def async_set_rgbw(self, rgbw: tuple[int, int, int, int]) -> None:
+        packed = (rgbw[0] << 24) | (rgbw[1] << 16) | (rgbw[2] << 8) | rgbw[3]
+        await self._send({"OnOff": 1, "RGBW": ctypes.c_int32(packed).value})
+
+    async def async_set_cct(self, cct: int) -> None:
+        await self._send({"OnOff": 1, "CCT": cct})

--- a/custom_components/aidot/ble_gateway_client.py
+++ b/custom_components/aidot/ble_gateway_client.py
@@ -15,6 +15,8 @@ from aidot.aes_utils import aes_encrypt as _aes_encrypt_raw, aes_decrypt as _aes
 
 _HUB_PORT = 10000
 _TIMEOUT = 8
+_MAX_RETRIES = 3
+_BACKOFF = 0.5
 
 
 def _make_aes_key(key_str: str) -> bytes:
@@ -74,6 +76,135 @@ def _next_seq() -> str:
     global _seq
     _seq += 1
     return "ha93" + str(_seq).zfill(5)
+
+
+class _HubSession:
+    """One persistent, serialised connection to an AiDot hub.
+
+    All BLE devices behind the same hub share a single session, so a per-hub
+    lock serialises commands (the hub resets the socket on concurrent logins)
+    and one logged-in connection is reused across commands (removing the
+    per-command connect+login latency). Transient drops are retried; the retry
+    path also recovers a connection the hub closed while idle.
+    """
+
+    def __init__(
+        self,
+        hub_id: str,
+        hub_ip: str,
+        aes_key: bytes,
+        user_id: str,
+        hub_password: str,
+    ) -> None:
+        self._hub_id = hub_id
+        self._hub_ip = hub_ip
+        self._aes_key = aes_key
+        self._user_id = user_id
+        self._hub_password = hub_password
+        self._lock = asyncio.Lock()
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._asc = 1
+
+    async def send_command(self, dev_id: str, attr: dict) -> None:
+        """Serialise, (re)connect as needed, and send one setDevAttr command."""
+        async with self._lock:
+            for attempt in range(_MAX_RETRIES):
+                try:
+                    await self._ensure_connected()
+                    await self._send_set_attr(dev_id, attr)
+                    return
+                except (
+                    ConnectionError,
+                    asyncio.TimeoutError,
+                    asyncio.IncompleteReadError,
+                ):
+                    await self._close()
+                    if attempt == _MAX_RETRIES - 1:
+                        raise
+                    await asyncio.sleep(_BACKOFF * (attempt + 1))
+
+    async def _ensure_connected(self) -> None:
+        if self._writer is None or self._writer.is_closing():
+            await self._connect_and_login()
+
+    async def _connect_and_login(self) -> None:
+        self._reader, self._writer = await asyncio.wait_for(
+            asyncio.open_connection(self._hub_ip, _HUB_PORT), timeout=_TIMEOUT
+        )
+        seq = str(int(time.time() * 1000) + 1)[-9:]
+        login = json.dumps({
+            "service": "device",
+            "method": "loginReq",
+            "seq": seq,
+            "srcAddr": self._user_id,
+            "deviceId": self._hub_id,
+            "payload": {
+                "userId": self._user_id,
+                "password": self._hub_password,
+                "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "ascNumber": 1,
+            },
+        }).encode()
+        self._writer.write(_frame(login, self._aes_key))
+        await self._writer.drain()
+        resp = await _recv(self._reader, self._aes_key)
+        self._asc = resp.get("payload", {}).get("ascNumber", 1) + 1
+
+    async def _send_set_attr(self, dev_id: str, attr: dict) -> None:
+        cmd = json.dumps({
+            "method": "setDevAttrReq",
+            "service": "device",
+            "clientId": "ha-" + self._user_id,
+            "srcAddr": "0." + self._user_id,
+            "seq": _next_seq(),
+            "payload": {
+                "devId": dev_id,
+                "parentId": self._hub_id,
+                "userId": self._user_id,
+                "password": self._hub_password,
+                "attr": attr,
+                "channel": "ble",
+                "ascNumber": self._asc,
+            },
+            "tst": int(time.time() * 1000),
+            "deviceId": dev_id,
+        }).encode()
+        self._asc += 1
+        self._writer.write(_frame(cmd, self._aes_key))
+        await self._writer.drain()
+        await _recv(self._reader, self._aes_key)
+
+    async def _close(self) -> None:
+        writer = self._writer
+        self._reader = None
+        self._writer = None
+        if writer is not None:
+            try:
+                writer.close()
+            except Exception:  # noqa: BLE001 - closing is best-effort
+                pass
+
+
+_HUB_SESSIONS: dict[str, _HubSession] = {}
+
+
+def _get_hub_session(
+    hub_id: str, hub_ip: str, aes_key: bytes, user_id: str, hub_password: str
+) -> _HubSession:
+    """Return the shared session for a hub, creating it on first use."""
+    session = _HUB_SESSIONS.get(hub_id)
+    if session is None or session._hub_ip != hub_ip:
+        session = _HubSession(hub_id, hub_ip, aes_key, user_id, hub_password)
+        _HUB_SESSIONS[hub_id] = session
+    return session
+
+
+async def close_all_hub_sessions() -> None:
+    """Close every open hub connection and clear the registry (on unload)."""
+    for session in list(_HUB_SESSIONS.values()):
+        await session._close()
+    _HUB_SESSIONS.clear()
 
 
 class BleGatewayDeviceClient:
@@ -139,53 +270,14 @@ class BleGatewayDeviceClient:
         self.on_status_update: Any = None
 
     async def _send(self, attr: dict) -> None:
-        reader, writer = await asyncio.wait_for(
-            asyncio.open_connection(self._hub_ip, _HUB_PORT), timeout=_TIMEOUT
+        session = _get_hub_session(
+            self._hub_id,
+            self._hub_ip,
+            self._aes_key,
+            self._user_id,
+            self._hub_password,
         )
-        try:
-            seq = str(int(time.time() * 1000) + 1)[-9:]
-            login = json.dumps({
-                "service": "device",
-                "method": "loginReq",
-                "seq": seq,
-                "srcAddr": self._user_id,
-                "deviceId": self._hub_id,
-                "payload": {
-                    "userId": self._user_id,
-                    "password": self._hub_password,
-                    "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
-                    "ascNumber": 1,
-                },
-            }).encode()
-            writer.write(_frame(login, self._aes_key))
-            await writer.drain()
-
-            resp = await _recv(reader, self._aes_key)
-            asc = resp.get("payload", {}).get("ascNumber", 1) + 1
-
-            cmd = json.dumps({
-                "method": "setDevAttrReq",
-                "service": "device",
-                "clientId": "ha-" + self._user_id,
-                "srcAddr": "0." + self._user_id,
-                "seq": _next_seq(),
-                "payload": {
-                    "devId": self._device_id,
-                    "parentId": self._hub_id,
-                    "userId": self._user_id,
-                    "password": self._hub_password,
-                    "attr": attr,
-                    "channel": "ble",
-                    "ascNumber": asc,
-                },
-                "tst": int(time.time() * 1000),
-                "deviceId": self._device_id,
-            }).encode()
-            writer.write(_frame(cmd, self._aes_key))
-            await writer.drain()
-            await _recv(reader, self._aes_key)
-        finally:
-            writer.close()
+        await session.send_command(self._device_id, attr)
 
         if "OnOff" in attr:
             self.status.on = bool(attr["OnOff"])

--- a/custom_components/aidot/coordinator.py
+++ b/custom_components/aidot/coordinator.py
@@ -21,12 +21,15 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from .ble_gateway_client import BleGatewayDeviceClient
 from .const import DOMAIN
 
 type AidotConfigEntry = ConfigEntry[AidotDeviceManagerCoordinator]
 _LOGGER = logging.getLogger(__name__)
 
 UPDATE_DEVICE_LIST_INTERVAL = timedelta(hours=6)
+
+_HUB_TYPE = "BleMesh_Hub"
 
 
 class AidotDeviceUpdateCoordinator(DataUpdateCoordinator[DeviceStatusData]):
@@ -99,15 +102,36 @@ class AidotDeviceManagerCoordinator(DataUpdateCoordinator[None]):
             data = await self.client.async_get_all_device()
         except AidotAuthFailed as error:
             raise ConfigEntryAuthFailed from error
-        current_devices = {
-            device[CONF_ID]: device
-            for device in data[CONF_DEVICE_LIST]
+
+        all_devices: list[dict] = data[CONF_DEVICE_LIST]
+
+        hub_devices = {
+            d[CONF_ID]: d
+            for d in all_devices
+            if d.get(CONF_TYPE) == _HUB_TYPE
+        }
+
+        wifi_devices = {
+            d[CONF_ID]: d
+            for d in all_devices
             if (
-                device[CONF_TYPE] == "light"
-                and CONF_AES_KEY in device
-                and device[CONF_AES_KEY][0] is not None
+                d.get(CONF_TYPE) == "light"
+                and CONF_AES_KEY in d
+                and d[CONF_AES_KEY][0] is not None
             )
         }
+
+        ble_devices = {
+            d[CONF_ID]: d
+            for d in all_devices
+            if (
+                d.get(CONF_TYPE) == "light"
+                and d.get("directGateway") in hub_devices
+                and d.get("bleMeshDeviceKey") is not None
+            )
+        }
+
+        current_devices = {**wifi_devices, **ble_devices}
 
         removed_ids = set(self.device_coordinators) - set(current_devices)
         for dev_id in removed_ids:
@@ -116,9 +140,23 @@ class AidotDeviceManagerCoordinator(DataUpdateCoordinator[None]):
         if removed_ids:
             self._purge_deleted_lists()
 
+        user_id: str = self.config_entry.data.get(CONF_ID, "")
+
         for dev_id, device in current_devices.items():
             if dev_id not in self.device_coordinators:
-                device_client = self.client.get_device_client(device)
+                if dev_id in ble_devices:
+                    hub_device = hub_devices[device["directGateway"]]
+                    device_client: DeviceClient | BleGatewayDeviceClient = (
+                        BleGatewayDeviceClient(device, hub_device, user_id)
+                    )
+                    _LOGGER.debug(
+                        "Using BLE gateway client for %s via hub %s",
+                        device.get("name"),
+                        hub_device.get("name"),
+                    )
+                else:
+                    device_client = self.client.get_device_client(device)
+
                 device_coordinator = AidotDeviceUpdateCoordinator(
                     self.hass, self.config_entry, device_client
                 )
@@ -144,7 +182,6 @@ class AidotDeviceManagerCoordinator(DataUpdateCoordinator[None]):
 
     def _purge_deleted_lists(self) -> None:
         """Purge device entries of deleted lists."""
-
         device_reg = dr.async_get(self.hass)
         identifiers = {
             (

--- a/custom_components/aidot/coordinator.py
+++ b/custom_components/aidot/coordinator.py
@@ -21,7 +21,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .ble_gateway_client import BleGatewayDeviceClient
+from .ble_gateway_client import BleGatewayDeviceClient, close_all_hub_sessions
 from .const import DOMAIN
 
 type AidotConfigEntry = ConfigEntry[AidotDeviceManagerCoordinator]
@@ -172,6 +172,7 @@ class AidotDeviceManagerCoordinator(DataUpdateCoordinator[None]):
         """Perform cleanup actions."""
         for coordinator in self.device_coordinators.values():
             coordinator.device_client.on_status_update = None
+        await close_all_hub_sessions()
         await self.client.async_cleanup()
 
     def token_fresh_cb(self) -> None:

--- a/custom_components/aidot/coordinator.py
+++ b/custom_components/aidot/coordinator.py
@@ -82,9 +82,12 @@ class AidotDeviceManagerCoordinator(DataUpdateCoordinator[None]):
             name=DOMAIN,
             update_interval=UPDATE_DEVICE_LIST_INTERVAL,
         )
+        # Unwrap old nested {"login_info": {...}} format: python-aidot 0.3.54b2 client.py
+        # references CONF_LOGIN_INFO without importing it (NameError on old-format entries).
+        token_data = config_entry.data.get("login_info", config_entry.data)
         self.client = AidotClient(
             session=async_get_clientsession(hass),
-            token=config_entry.data,
+            token=token_data,
         )
         self.client.set_token_fresh_cb(self.token_fresh_cb)
         self.device_coordinators: dict[str, AidotDeviceUpdateCoordinator] = {}
@@ -140,7 +143,9 @@ class AidotDeviceManagerCoordinator(DataUpdateCoordinator[None]):
         if removed_ids:
             self._purge_deleted_lists()
 
-        user_id: str = self.config_entry.data.get(CONF_ID, "")
+        # Handle both old (nested login_info) and new (flat) config entry data formats
+        login_data = self.config_entry.data.get("login_info", self.config_entry.data)
+        user_id: str = login_data.get("id", "")
 
         for dev_id, device in current_devices.items():
             if dev_id not in self.device_coordinators:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Make the integration's modules importable standalone.
+
+``ble_gateway_client`` only depends on the stdlib and the installed ``aidot``
+library (no relative imports), so we put the integration dir on ``sys.path``
+and import the module directly — avoiding the package ``__init__`` which would
+pull in Home Assistant.
+"""
+
+import sys
+from pathlib import Path
+
+_AIDOT_DIR = Path(__file__).resolve().parent.parent / "custom_components" / "aidot"
+sys.path.insert(0, str(_AIDOT_DIR))

--- a/tests/test_ble_gateway_client.py
+++ b/tests/test_ble_gateway_client.py
@@ -1,0 +1,282 @@
+"""Transport-layer tests for ble_gateway_client.
+
+These exercise the per-hub session: a shared lock (serialises the 8 entities
+that share one hub), connection reuse (login once, reuse the socket), and retry
+on transient connection errors. The socket layer is faked; the AES framing is
+real (round-tripped through the installed ``aidot`` library).
+"""
+
+import asyncio
+import json
+
+import pytest
+
+import ble_gateway_client as bgc
+
+
+# --- fakes -----------------------------------------------------------------
+
+
+class _Tracker:
+    """Counts max concurrent entries to detect interleaving."""
+
+    def __init__(self) -> None:
+        self.active = 0
+        self.max = 0
+
+    def enter(self) -> None:
+        self.active += 1
+        self.max = max(self.max, self.active)
+
+    def exit(self) -> None:
+        self.active -= 1
+
+
+class FakeWriter:
+    def __init__(self, tracker: _Tracker | None = None) -> None:
+        self.tracker = tracker
+        self.writes: list[bytes] = []
+        self._closed = False
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    async def drain(self) -> None:
+        # Yield control so a second, unsynchronised command could interleave.
+        if self.tracker is not None:
+            self.tracker.enter()
+            await asyncio.sleep(0)
+            self.tracker.exit()
+        else:
+            await asyncio.sleep(0)
+
+    def close(self) -> None:
+        self._closed = True
+
+    def is_closing(self) -> bool:
+        return self._closed
+
+    async def wait_closed(self) -> None:
+        pass
+
+
+class FakeReader:
+    """Serves pre-framed bytes; raises ``exc`` once the buffer is exhausted."""
+
+    def __init__(self, frames: list[bytes], exc: Exception | None = None) -> None:
+        self._buf = b"".join(frames)
+        self._pos = 0
+        self._exc = exc or ConnectionResetError(104, "reset")
+
+    async def readexactly(self, n: int) -> bytes:
+        if len(self._buf) - self._pos < n:
+            raise self._exc
+        chunk = self._buf[self._pos : self._pos + n]
+        self._pos += n
+        return chunk
+
+
+class FakeServer:
+    """Hands out one (reader, writer) per ``open_connection`` call."""
+
+    def __init__(self, conn_specs: list[dict]) -> None:
+        # Each spec: {"frames": [...], "exc": Exception|None, "tracker": Tracker|None}
+        self._specs = conn_specs
+        self.connect_count = 0
+        self.writers: list[FakeWriter] = []
+        self.readers: list[FakeReader] = []
+
+    async def open_connection(self, host, port):
+        spec = self._specs[min(self.connect_count, len(self._specs) - 1)]
+        self.connect_count += 1
+        reader = FakeReader(spec.get("frames", []), spec.get("exc"))
+        writer = FakeWriter(spec.get("tracker"))
+        self.readers.append(reader)
+        self.writers.append(writer)
+        return reader, writer
+
+
+# --- helpers ---------------------------------------------------------------
+
+KEY = bgc._make_aes_key("testkey")
+
+
+def _frame_obj(obj: dict) -> bytes:
+    return bgc._frame(json.dumps(obj).encode(), KEY)
+
+
+def _login_frame(asc: int = 5) -> bytes:
+    return _frame_obj({"payload": {"ascNumber": asc}})
+
+
+def _ack_frame() -> bytes:
+    return _frame_obj({"payload": {}})
+
+
+def _session() -> "bgc._HubSession":
+    return bgc._HubSession(
+        hub_id="hub1",
+        hub_ip="10.0.0.5",
+        aes_key=KEY,
+        user_id="user1",
+        hub_password="pw",
+    )
+
+
+def _count_logins(writer: FakeWriter) -> int:
+    """Decode written frames and count loginReq messages."""
+    count = 0
+    for data in writer.writes:
+        body = data[8:]  # strip 8-byte header
+        try:
+            msg = json.loads(bgc._aes_decrypt(body, KEY))
+        except Exception:
+            continue
+        if msg.get("method") == "loginReq":
+            count += 1
+    return count
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    bgc._HUB_SESSIONS.clear()
+    yield
+    bgc._HUB_SESSIONS.clear()
+
+
+# --- tests -----------------------------------------------------------------
+
+
+async def test_concurrent_commands_serialise(monkeypatch):
+    """Two commands racing on the same hub must not interleave (shared lock)."""
+    tracker = _Tracker()
+    # One connection, reused; enough acks for both commands.
+    server = FakeServer(
+        [{"frames": [_login_frame(), _ack_frame(), _ack_frame()], "tracker": tracker}]
+    )
+    monkeypatch.setattr(bgc.asyncio, "open_connection", server.open_connection)
+
+    sess = _session()
+    await asyncio.gather(
+        sess.send_command("devA", {"OnOff": 1}),
+        sess.send_command("devB", {"OnOff": 0}),
+    )
+
+    assert tracker.max == 1, "commands interleaved — lock not held across the call"
+
+
+async def test_connection_is_reused_login_once(monkeypatch):
+    """Sequential commands reuse the socket and log in exactly once."""
+    server = FakeServer(
+        [{"frames": [_login_frame(), _ack_frame(), _ack_frame()]}]
+    )
+    monkeypatch.setattr(bgc.asyncio, "open_connection", server.open_connection)
+
+    sess = _session()
+    await sess.send_command("devA", {"OnOff": 1})
+    await sess.send_command("devA", {"OnOff": 0})
+
+    assert server.connect_count == 1, "opened a new connection instead of reusing"
+    assert _count_logins(server.writers[0]) == 1, "logged in more than once"
+
+
+async def test_ascnumber_increments_per_command(monkeypatch):
+    """Reused connection bumps ascNumber per command (login asc was 5)."""
+    server = FakeServer(
+        [{"frames": [_login_frame(asc=5), _ack_frame(), _ack_frame()]}]
+    )
+    monkeypatch.setattr(bgc.asyncio, "open_connection", server.open_connection)
+
+    sess = _session()
+    await sess.send_command("devA", {"OnOff": 1})
+    await sess.send_command("devA", {"OnOff": 0})
+
+    ascs = []
+    for data in server.writers[0].writes:
+        msg = json.loads(bgc._aes_decrypt(data[8:], KEY))
+        if msg.get("method") == "setDevAttrReq":
+            ascs.append(msg["payload"]["ascNumber"])
+    assert ascs == [6, 7], f"expected ascNumber 6,7 got {ascs}"
+
+
+async def test_retry_reconnects_after_reset(monkeypatch):
+    """A transient reset on the first attempt triggers reconnect + relogin."""
+    monkeypatch.setattr(bgc, "_BACKOFF", 0)
+    server = FakeServer(
+        [
+            {"frames": [_login_frame()], "exc": ConnectionResetError(104, "reset")},
+            {"frames": [_login_frame(), _ack_frame()]},
+        ]
+    )
+    monkeypatch.setattr(bgc.asyncio, "open_connection", server.open_connection)
+
+    sess = _session()
+    await sess.send_command("devA", {"OnOff": 1})
+
+    assert server.connect_count == 2, "did not reconnect after reset"
+
+
+async def test_retry_gives_up_after_max_attempts(monkeypatch):
+    """Persistent failure raises after _MAX_RETRIES attempts."""
+    monkeypatch.setattr(bgc, "_BACKOFF", 0)
+    server = FakeServer(
+        [{"frames": [_login_frame()], "exc": ConnectionResetError(104, "reset")}]
+    )
+    monkeypatch.setattr(bgc.asyncio, "open_connection", server.open_connection)
+
+    sess = _session()
+    with pytest.raises(ConnectionResetError):
+        await sess.send_command("devA", {"OnOff": 1})
+
+    assert server.connect_count == bgc._MAX_RETRIES
+
+
+async def test_close_all_hub_sessions_clears_registry(monkeypatch):
+    """close_all_hub_sessions() closes live writers and empties the registry."""
+    server = FakeServer([{"frames": [_login_frame(), _ack_frame()]}])
+    monkeypatch.setattr(bgc.asyncio, "open_connection", server.open_connection)
+
+    client = _make_client()
+    await client.async_turn_on()
+    assert bgc._HUB_SESSIONS  # session was created
+
+    await bgc.close_all_hub_sessions()
+
+    assert not bgc._HUB_SESSIONS
+    assert server.writers[0].is_closing()
+
+
+# --- behaviour preserved through the client (regression guard) -------------
+
+
+def _make_client() -> "bgc.BleGatewayDeviceClient":
+    device = {
+        "id": "devA",
+        "mac": "AA:BB",
+        "name": "Spot 1",
+        "product": {"serviceModules": []},
+        "properties": {},
+    }
+    hub = {
+        "id": "hub1",
+        "password": "pw",
+        "aesKey": ["testkey"],
+        "properties": {"ipAddress": "10.0.0.5"},
+    }
+    return bgc.BleGatewayDeviceClient(device, hub, "user1")
+
+
+async def test_optimistic_status_updates_after_command(monkeypatch):
+    """async_set_brightness still updates cached status and fires the callback."""
+    server = FakeServer([{"frames": [_login_frame(), _ack_frame()]}])
+    monkeypatch.setattr(bgc.asyncio, "open_connection", server.open_connection)
+
+    client = _make_client()
+    seen = []
+    client.on_status_update = seen.append
+
+    await client.async_set_brightness(255)
+
+    assert client.status.on is True
+    assert client.status.dimming == 255
+    assert seen and seen[-1] is client.status


### PR DESCRIPTION
## Problem

Devices connected to a `BleMesh_Hub` (e.g. Linkind outdoor solar spotlights) have `aesKey: [null]` and are silently dropped by the existing wifi-only device filter in `coordinator.py`. They never appear as entities in Home Assistant.

## Solution

Detect BLE mesh lights (those with a `directGateway` pointing to a `BleMesh_Hub` and a `bleMeshDeviceKey`) and route them through a new `BleGatewayDeviceClient` instead of the wifi `DeviceClient`.

`BleGatewayDeviceClient` is a duck-typed drop-in for `DeviceClient`. It controls BLE mesh lights by:
1. Opening a TCP connection to the hub on port 10000
2. Logging in with hub credentials (AES-ECB encrypted protocol)
3. Forwarding a `setDevAttrReq` with `channel='ble'` — the hub relays it to the device over BLE mesh
4. After each successful command, updating local status and calling `on_status_update` so the HA state machine reflects the change immediately

## Transport robustness (per-hub session)

All lights behind a hub share **one** TCP endpoint. The naive "connect + log in + send + close per command" approach breaks down in practice: with several entities issuing commands concurrently, the hub resets the socket (`ConnectionResetError [Errno 104]` → HTTP 500, partial apply), transient drops are lost, and every command pays connect+login latency.

A per-hub `_HubSession` (keyed by hub id, shared across all `BleGatewayDeviceClient` instances for that hub) addresses this:
- **Shared `asyncio.Lock`** serialises all commands to a hub, so concurrent calls no longer collide and reset the gateway.
- **Connection reuse**: the session keeps one logged-in connection open and reuses it (login once, increment `ascNumber` per command), removing per-command connect+login latency.
- **Bounded retry with backoff** on `ConnectionError`/`TimeoutError`/`IncompleteReadError`; the retry path also transparently reconnects + re-logs-in if the hub closed an idle socket, so reuse degrades gracefully to reconnect-per-command when a hub won't hold the connection.
- Sessions are closed on unload via the manager coordinator's `async_cleanup()`.

## Files changed

- `coordinator.py`: split the device list into `hub_devices`, `wifi_devices`, and `ble_devices`; route BLE devices to `BleGatewayDeviceClient`; close hub sessions on cleanup. Also handles the old nested `{"login_info": {...}}` config-entry format (older entries would otherwise raise `NameError`).
- `ble_gateway_client.py` (new): BLE gateway client + per-hub `_HubSession` (lock/reuse/retry); reuses `aidot.aes_utils` from `python-aidot` for AES operations.
- `tests/test_ble_gateway_client.py` (new): standalone unit tests (faked socket, real AES framing) covering serialisation, connection reuse / single login, `ascNumber` sequencing, retry recovery, give-up-after-max, and session cleanup.

## Testing

Tested with 8x Linkind A000181 solar spotlights (model `LK.A000181`) connected via a `BleMesh_Hub`. All entities appear correctly; on/off, brightness, CCT and RGBW control all work. Capabilities (CCT range 2700–6500K, RGBW support) are derived from `product.serviceModules`.

Unit tests: `pytest -q` → all green (no Home Assistant harness needed; the transport layer is self-contained).

## Notes

- WiFi device behavior is unchanged — the new code path only activates for devices that have `directGateway` set to a known hub.
- The connection to a hub is now **persistent and serialised per hub** (one shared, logged-in socket reused across that hub's lights), replacing the earlier connect-per-command approach.
