### PR TITLE
Apply all supplied turn_on attributes

### DIFF
--- a/custom_components/aidot/light.py
+++ b/custom_components/aidot/light.py
@@ -89,25 +89,33 @@ class AidotLight(CoordinatorEntity[AidotDeviceUpdateCoordinator], LightEntity):
         super()._handle_coordinator_update()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the light on, applying brightness, color temperature, RGBW, or plain on."""
-        if ATTR_BRIGHTNESS in kwargs:
-            brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
-            await self.coordinator.device_client.async_set_brightness(brightness)
-            self.coordinator.data.dimming = brightness
-            self._attr_brightness = brightness
-        elif ATTR_COLOR_TEMP_KELVIN in kwargs:
-            color_temp_kelvin = kwargs.get(ATTR_COLOR_TEMP_KELVIN)
-            await self.coordinator.device_client.async_set_cct(color_temp_kelvin)
-            self.coordinator.data.cct = color_temp_kelvin
-            self._attr_color_temp_kelvin = color_temp_kelvin
-            self._attr_color_mode = ColorMode.COLOR_TEMP
-        elif ATTR_RGBW_COLOR in kwargs:
+        """Turn the light on, applying all supplied attributes."""
+        handled = False
+
+        if ATTR_RGBW_COLOR in kwargs:
             rgbw_color = kwargs.get(ATTR_RGBW_COLOR)
             await self.coordinator.device_client.async_set_rgbw(rgbw_color)
             self.coordinator.data.rgbw = rgbw_color
             self._attr_rgbw_color = rgbw_color
             self._attr_color_mode = ColorMode.RGBW
-        else:
+            handled = True
+
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            color_temp_kelvin = kwargs.get(ATTR_COLOR_TEMP_KELVIN)
+            await self.coordinator.device_client.async_set_cct(color_temp_kelvin)
+            self.coordinator.data.cct = color_temp_kelvin
+            self._attr_color_temp_kelvin = color_temp_kelvin
+            self._attr_color_mode = ColorMode.COLOR_TEMP
+            handled = True
+
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+            await self.coordinator.device_client.async_set_brightness(brightness)
+            self.coordinator.data.dimming = brightness
+            self._attr_brightness = brightness
+            handled = True
+
+        if not handled:
             await self.coordinator.device_client.async_turn_on()
 
         self.coordinator.data.on = True


### PR DESCRIPTION
## Summary

This Home Assistant integration PR fixes `AidotLight.async_turn_on()` so it applies all supported attributes supplied in a single `light.turn_on` call.

Home Assistant commonly calls `light.turn_on` with multiple attributes, for example color plus brightness. The previous `elif` chain meant only the first matching branch was applied, so one attribute could silently suppress the others.

## Details

- Applies RGBW, color temperature, and brightness independently when present.
- Preserves existing bare `turn_on()` behavior when no supported attributes are supplied.
- Keeps the integration thin; the related local-IP fallback and off-state device-attribute bug are handled in the companion `python-aidot` draft PR.

## Companion dependency

This PR should stay draft until the library-side fixes are released and the manifest pin can be bumped:

- python-AiDot draft PR: https://github.com/AiDot-Development-Team/python-AiDot/pull/4

That companion PR fixes:

- `DeviceClient.send_dev_attr()` using undefined `attr` instead of `dev_attr` when applying attrs while the device is off.
- Cloud `properties.ipAddress` fallback inside `AidotClient.get_device_client()` without requiring Home Assistant to read private `_ip_address` state.

## Validation

- `py_compile` passes for `custom_components/aidot/coordinator.py` and `custom_components/aidot/light.py`.
- `git diff --check` passes.
- Live validation was performed with local patches against two AiDot/Linkind BR30 bulbs:
  - combined `light.turn_on` from off state with `hs_color` + `brightness` correctly turned the bulbs on and applied both attributes;
  - holiday automation using color + brightness verified successfully.
