### PR TITLE
Fix SyntaxError in config_flow.py (Python 2 except syntax)

### DIFF
--- a/custom_components/aidot/config_flow.py
+++ b/custom_components/aidot/config_flow.py
@@ -56,7 +56,7 @@ class AidotConfigFlow(ConfigFlow, domain=DOMAIN):
                 login_info = await client.async_post_login()
             except AidotUserOrPassIncorrect:
                 errors["base"] = "invalid_auth"
-            except TimeoutError, ClientError:
+            except (TimeoutError, ClientError):
                 errors["base"] = "cannot_connect"
 
             if not errors:
@@ -97,7 +97,7 @@ class AidotConfigFlow(ConfigFlow, domain=DOMAIN):
                 login_info = await client.async_post_login()
             except AidotUserOrPassIncorrect:
                 errors["base"] = "invalid_auth"
-            except TimeoutError, ClientError:
+            except (TimeoutError, ClientError):
                 errors["base"] = "cannot_connect"
 
             if not errors:


### PR DESCRIPTION
`config_flow.py` currently has two `except` clauses using Python 2 comma syntax:

```python
except TimeoutError, ClientError:
```

This is a `SyntaxError` in Python 3, so the module fails to import. Symptoms on current `main`:

- Adding the integration fails with **"Config flow could not be loaded: Invalid handler specified"** (HA can't import the flow handler).
- Existing config entries fail to set up, since the integration package can't be imported during entry setup.

This PR parenthesizes the exception tuples in both places (`async_step_user` and the reauth step) — a two-line change, no behavior change otherwise. Verified with `py_compile` and against a live account/hub setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)