### PR TITLE
Fix legacy config entry reauthentication

### DIFF
--- a/custom_components/aidot/auth.py
+++ b/custom_components/aidot/auth.py
@@ -1,0 +1,37 @@
+"""Helpers for reading AiDot credentials from config entries."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from aidot.const import CONF_COUNTRY, DEFAULT_COUNTRY_CODE, SUPPORTED_COUNTRYS
+
+_CONF_COUNTRY_CODE = "country_code"
+_LEGACY_LOGIN_INFO_KEYS = ("login_info", "loginInfo")
+
+
+def get_login_data(entry_data: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return login data from either a flat or legacy nested config entry."""
+    for key in _LEGACY_LOGIN_INFO_KEYS:
+        nested_data = entry_data.get(key)
+        if isinstance(nested_data, Mapping):
+            return nested_data
+    return entry_data
+
+
+def get_country_code(entry_data: Mapping[str, Any]) -> str:
+    """Return the stored country code, deriving it for older config entries."""
+    login_data = get_login_data(entry_data)
+
+    for data in (entry_data, login_data):
+        country_code = data.get(_CONF_COUNTRY_CODE)
+        if isinstance(country_code, str) and country_code:
+            return country_code
+
+    country_name = login_data.get(CONF_COUNTRY) or entry_data.get(CONF_COUNTRY)
+    if isinstance(country_name, str):
+        normalized_name = country_name.casefold()
+        for country in SUPPORTED_COUNTRYS:
+            if country["name"].casefold() == normalized_name:
+                return country["id"]
+
+    return DEFAULT_COUNTRY_CODE

--- a/custom_components/aidot/config_flow.py
+++ b/custom_components/aidot/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.const import CONF_COUNTRY_CODE, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .auth import get_country_code, get_login_data
 from .const import DOMAIN
 
 DATA_SCHEMA = vol.Schema(
@@ -56,7 +57,7 @@ class AidotConfigFlow(ConfigFlow, domain=DOMAIN):
                 login_info = await client.async_post_login()
             except AidotUserOrPassIncorrect:
                 errors["base"] = "invalid_auth"
-            except TimeoutError, ClientError:
+            except (TimeoutError, ClientError):
                 errors["base"] = "cannot_connect"
 
             if not errors:
@@ -85,31 +86,40 @@ class AidotConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle reauth confirmation."""
         errors: dict[str, str] = {}
         reauth_entry = self._get_reauth_entry()
+        login_data = get_login_data(reauth_entry.data)
+        country_code = get_country_code(reauth_entry.data)
+        username = login_data.get(CONF_USERNAME, "")
 
         if user_input is not None:
             client = AidotClient(
                 session=async_get_clientsession(self.hass),
-                country_code=reauth_entry.data[CONF_COUNTRY_CODE],
-                username=reauth_entry.data[CONF_USERNAME],
+                country_code=country_code,
+                username=username,
                 password=user_input[CONF_PASSWORD],
             )
             try:
                 login_info = await client.async_post_login()
             except AidotUserOrPassIncorrect:
                 errors["base"] = "invalid_auth"
-            except TimeoutError, ClientError:
+            except (TimeoutError, ClientError):
                 errors["base"] = "cannot_connect"
 
             if not errors:
+                # Replace, rather than merge, the entry so a stale legacy
+                # login_info dictionary cannot take precedence after reload.
                 return self.async_update_reload_and_abort(
-                    reauth_entry, data_updates=login_info
+                    reauth_entry,
+                    data={
+                        **login_info,
+                        CONF_COUNTRY_CODE: country_code,
+                        CONF_USERNAME: username,
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
                 )
 
         return self.async_show_form(
             step_id="reauth_confirm",
             data_schema=REAUTH_SCHEMA,
-            description_placeholders={
-                "username": reauth_entry.data.get(CONF_USERNAME, "")
-            },
+            description_placeholders={"username": username},
             errors=errors,
         )

--- a/custom_components/aidot/coordinator.py
+++ b/custom_components/aidot/coordinator.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from .auth import get_login_data
 from .const import DOMAIN
 
 type AidotConfigEntry = ConfigEntry[AidotDeviceManagerCoordinator]
@@ -81,7 +82,7 @@ class AidotDeviceManagerCoordinator(DataUpdateCoordinator[None]):
         )
         self.client = AidotClient(
             session=async_get_clientsession(hass),
-            token=config_entry.data,
+            token=get_login_data(config_entry.data),
         )
         self.client.set_token_fresh_cb(self.token_fresh_cb)
         self.device_coordinators: dict[str, AidotDeviceUpdateCoordinator] = {}

--- a/custom_components/aidot/manifest.json
+++ b/custom_components/aidot/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "quality_scale": "bronze",
   "requirements": [
-    "python-aidot==0.3.54b4"
+    "python-aidot==0.3.56"
   ],
-  "version": "1.1.4-beta.4"
+  "version": "1.1.4-beta.5"
 }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,46 @@
+"""Tests for config-entry credential compatibility helpers."""
+
+import importlib.util
+from pathlib import Path
+
+_AUTH_PATH = (
+    Path(__file__).resolve().parent.parent / "custom_components" / "aidot" / "auth.py"
+)
+_AUTH_SPEC = importlib.util.spec_from_file_location("aidot_auth", _AUTH_PATH)
+assert _AUTH_SPEC is not None and _AUTH_SPEC.loader is not None
+auth = importlib.util.module_from_spec(_AUTH_SPEC)
+_AUTH_SPEC.loader.exec_module(auth)
+
+
+def test_get_login_data_supports_legacy_snake_case() -> None:
+    """The v1.0.8 login_info wrapper is unwrapped."""
+    login_data = {"username": "user@example.com", "country": "United States"}
+
+    assert auth.get_login_data({"login_info": login_data}) is login_data
+
+
+def test_get_login_data_supports_legacy_camel_case() -> None:
+    """The python-aidot loginInfo spelling is also unwrapped."""
+    login_data = {"username": "user@example.com", "country": "United States"}
+
+    assert auth.get_login_data({"loginInfo": login_data}) is login_data
+
+
+def test_get_country_code_uses_current_flat_value() -> None:
+    """Current entries retain their explicitly selected country code."""
+    assert auth.get_country_code({"country_code": "CA", "country": "Canada"}) == "CA"
+
+
+def test_get_country_code_derives_legacy_value() -> None:
+    """Legacy entries recover their country code from the stored country name."""
+    assert (
+        auth.get_country_code(
+            {
+                "login_info": {
+                    "username": "user@example.com",
+                    "country": "United States",
+                }
+            }
+        )
+        == "US"
+    )


### PR DESCRIPTION
## Summary

- read credentials from both current flat config entries and legacy `login_info` / `loginInfo` wrappers
- recover the missing country code in older entries from the stored country name
- replace stale legacy entry data after successful reauthentication instead of merging fresh tokens beside it
- update `python-aidot` from `0.3.54b4` to `0.3.56` for typed connection errors, isolated client state, declared dependencies, and the `send_dev_attr` fix
- use parenthesized multi-exception handlers so the config flow also parses on Python versions before 3.14

## Root cause

Entries created by older integration versions stored account data below `login_info`, while the current reauthentication flow reads `country_code` and `username` only from the top level. Submitting the password therefore raises `KeyError` before a login request is made.

The existing success path uses `data_updates`, which would retain the stale nested `login_info` value. The coordinator would continue selecting those expired credentials after reload. This change replaces the entry with normalized flat data once reauthentication succeeds.

## User impact

Users upgrading with an older config entry can reauthenticate in Home Assistant without deleting and recreating the integration. Current flat-format entries continue to use their explicitly stored country code.

## Validation

- `.venv/bin/python -m pytest -q tests/test_auth.py` — 4 passed
- `.venv/bin/python -m compileall -q custom_components tests`
- `jq empty custom_components/aidot/manifest.json`
- `git diff --check`

Addresses #23.
Fixes #33.

This does not address the separate recurring cloud-token invalidation or entity-availability behavior described in #34.
